### PR TITLE
Add attributes property to AlexaMock

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ class AlexaMock {
   constructor() {
     this.response = new AlexaResponseMock();
     this.event = {};
+    this.attributes = {};
     this.handler = {
       state: null
     }


### PR DESCRIPTION
## Overview

Real alexa handler has [these properties](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/blob/master/lib/alexa.js#L244)

I think don't cover all properties Immediately but `attributes` is very important one, because basically we use it when save datas to session attributes using official Alexa SDK.

https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/tree/master#skill-state-management

Please add it.